### PR TITLE
Support for .couchappignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ grunt.initConfig({
 Merge sources are expanded via [grunt.file.expand](http://gruntjs.com/api/grunt.file#grunt.file.expand)
 and compiled in exactly the same way as the other couch-compile targets.
 
+#### options.ignoreFiles
+
+If you have a .couchappignore file, it will populate options.ignoreFiles and pass them to 
+[couch-compile](https://github.com/jo/couch-compile), which will ignore those files. 
+
 ### The Couch Directory Tree
 
 is quite self-explanatory. For example:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "async": "~0.2.9",
     "mime": "~1.2.9",
     "lodash": "~2.4.1",
-    "couch-compile": "~1.0.1"
+    "couch-compile": "chrisekelley/couch-compile"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/couch-compile.js
+++ b/tasks/couch-compile.js
@@ -19,9 +19,11 @@ module.exports = function(grunt) {
     var shared = {};
     var done = this.async();
 
-    var ignoreFiles = grunt.file.read('.couchappignore')
-    var ignoreFilesArr = ignoreFiles.split('\n')
-    options.ignoreFiles = ignoreFilesArr;
+    if (grunt.file.exists('.couchappignore')) {
+      var ignoreFiles = grunt.file.read('.couchappignore')
+      var ignoreFilesArr = ignoreFiles.split('\n')
+      options.ignoreFiles = ignoreFilesArr;
+    }
 
     function processShared(dir, next) {
       compile(dir, options, function(err, doc) {
@@ -43,7 +45,7 @@ module.exports = function(grunt) {
         }
 
         _.merge(doc, shared);
-        
+
         grunt.log.write('Compiling ' + source + '...').ok();
         next(null, doc);
       });

--- a/tasks/couch-compile.js
+++ b/tasks/couch-compile.js
@@ -19,6 +19,10 @@ module.exports = function(grunt) {
     var shared = {};
     var done = this.async();
 
+    var ignoreFiles = grunt.file.read('.couchappignore')
+    var ignoreFilesArr = ignoreFiles.split('\n')
+    options.ignoreFiles = ignoreFilesArr;
+
     function processShared(dir, next) {
       compile(dir, options, function(err, doc) {
         if (err) {


### PR DESCRIPTION
The package.json points to my couch-compile repository, which has this feature implemented. If my pull request https://github.com/jo/couch-compile/pull/5 is accepted, then I'll change package.json to point to jo's repository.
