### PR TITLE
Update link to _replicator api

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Your password.
 
 ## The "couch-replication" task
 
-You can write [CouchDB _replicator Documents](http://couchdb.readthedocs.org/en/latest/replication.html)
+You can write [CouchDB _replicator Documents](http://couchdb.readthedocs.org/en/1.6.1/api/server/common.html#api-server-replicate)
 from project files with `couch-replication`.
 
 If there is already a replication document, it will gets deleted and recreated,


### PR DESCRIPTION
The link is broken. I've set it to point to couchdb 1.6.1, the original link pointed to 'latest' as the version, but as of this time that is pointing to the beta couchdb 2.0. I don't think the intent is to go to 2.0.