### PR TITLE
Use current compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "async": "~0.2.9",
     "mime": "~1.2.9",
     "lodash": "~2.4.1",
-    "couch-compile": "~1.0.1"
+    "couchdb-compile": "~1.6.2"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/couch-compile.js
+++ b/tasks/couch-compile.js
@@ -9,7 +9,7 @@
 'use strict';
 var _ = require('lodash');
 var async = require('async');
-var compile = require('couch-compile');
+var compile = require('couchdb-compile');
 
 module.exports = function(grunt) {
   grunt.registerMultiTask('couch-compile', 'Compile documents from directories, JSON files or modules.', function() {


### PR DESCRIPTION
Is there any reason not to use the latest couch(db)-compile?