### PR TITLE
Wu lee/use current compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "async": "~0.2.9",
     "mime": "~1.2.9",
     "lodash": "~2.4.1",
-    "couch-compile": "~1.0.1"
+    "couchdb-compile": "~1.6.2"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/couch-compile.js
+++ b/tasks/couch-compile.js
@@ -26,6 +26,9 @@ module.exports = function(grunt) {
         }
 
         _.merge(shared, doc);
+        
+        // Don't clobber _id attributes with a shared _id
+        delete shared._id;
 
         grunt.log.write('Compiling shared ' + dir + '...').ok();
         next(null, doc);

--- a/tasks/couch-compile.js
+++ b/tasks/couch-compile.js
@@ -9,7 +9,7 @@
 'use strict';
 var _ = require('lodash');
 var async = require('async');
-var compile = require('couch-compile');
+var compile = require('couchdb-compile');
 
 module.exports = function(grunt) {
   grunt.registerMultiTask('couch-compile', 'Compile documents from directories, JSON files or modules.', function() {


### PR DESCRIPTION
Uses couchdb-compile@~1.6.2 as per @argl's original pull request, but also includes a fix to make the tests pass.

I can confirm this version does not have the problem described in #26.  Due to [deficiencies in NodeJS/nodeunit's `deepEqual()` function](https://github.com/nodejs/node-v0.x-archive/issues/7161), I have not written a test which catches that issue, since I am currently unsure of what the best work around would be.