### PR TITLE
.travis.yml - avoid errors due to npm caret versions in node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: node_js
 node_js:
   - 0.10
   - 0.8
+before_install:
+  - npm update -q
 before_script:
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - 0.10
   - 0.8
 before_install:
-  - npm update -q npm@'>=1.4.3'
+  - npm update -g npm@'>=1.4.3'
 before_script:
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - 0.10
   - 0.8
 before_install:
-  - npm update -q npm
+  - npm update -q npm@'>=1.4.3'
 before_script:
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - 0.10
   - 0.8
 before_install:
-  - npm update -q
+  - npm update -q npm
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
A lot of builds are failing in travis like this:

    Error: No compatible version found: blah@'^1.2.0'
    Valid install targets:
    ...

Followed by a list including exactly the version specified.  Huh?
Well, the version of npm installed with nodejs v0.8 doesn't understand
caret versions.  Suggested fix is to upgrade it, as described here:

    https://stackoverflow.com/questions/25902927/travis-not-installing-npm-modules