### PR TITLE
tasks/couch-security.js - send JSON data

### DIFF
--- a/tasks/couch-security.js
+++ b/tasks/couch-security.js
@@ -22,7 +22,8 @@ module.exports = function(grunt) {
     }
 
     var req = request.defaults(defaults);
-    req(url + '/_security', { body: security }, function(err, resp, data) {
+    var securityJson = JSON.parse(security);
+    req(url + '/_security', { body: securityJson }, function(err, resp, data) {
       grunt.log.write(url + '...');
 
       if (err) {


### PR DESCRIPTION
Without this the data gets sent re-encoded as a JSON string, with the JSON quotes quoted etc.

So this:

    {
        "admins": {
            "names": [], "roles": []
        },
        "members": {
            "names": ["foo"], "roles": [],
        },
    }

Was being sent as a string like this:

    "{\n    \"admins\": {\n        \"names\": [], \"roles\": []\n    },\n    \"members\": {\n        \"names\": [\"foo\"], \"roles\": []\n    }\n}\n"

